### PR TITLE
Support running server without SSL

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,7 @@ if (argv.help) {
     '--help                 Display this help message and exit',
     '--port <port>          The port to listen on (default: 4567)',
     '--path <path>          The path to use for the LevelDB store (in-memory by default)',
+    '--ssl                  Enable SSL for the web server, disable with --no-ssl (default: true)',
     '--createStreamMs <ms>  Amount of time streams stay in CREATING state (default: 500)',
     '--deleteStreamMs <ms>  Amount of time streams stay in DELETING state (default: 500)',
     '--updateStreamMs <ms>  Amount of time streams stay in UPDATING state (default: 500)',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var https = require('https'),
+    http = require('http'),
     fs = require('fs'),
     crypto = require('crypto'),
     uuid = require('node-uuid'),
@@ -18,12 +19,18 @@ module.exports = kinesalite
 
 function kinesalite(options) {
   options = options || {}
+  var requestHandler = httpHandler.bind(null, db.create(options))
+
+  if (options.ssl === false) {
+    return http.createServer(requestHandler)
+  }
+
   options.key = options.key || fs.readFileSync(__dirname + '/key.pem')
   options.cert = options.cert || fs.readFileSync(__dirname + '/cert.pem')
   options.ca = options.ca || fs.readFileSync(__dirname + '/ca.pem')
   options.requestCert = true
   options.rejectUnauthorized = false
-  return https.createServer(options, httpHandler.bind(null, db.create(options)))
+  return https.createServer(options, requestHandler)
 }
 
 validOperations.forEach(function(action) {


### PR DESCRIPTION
Currently the server always runs with SSL and self-signed certs. This causes problems with the AWS SDK, which rejects self-signed certs by default (which is generally good).  You can get around this, but it requires some mucking around pretty deep in the SDK internals and makes this library a lot less of a drop in replacement for the API.

I assume the primary use case for this is local development/tests/etc, where SSL really isn't that important.  I think it probably makes sense to make non-SSL the default, but for compatibility I left SSL on by default and added a `--no-ssl` flag to disable it.

By the way, thanks a ton for the work you're doing on this library.  I wish I could contribute something more useful, especially on the getRecords/getShardIterator front but unfortunately I am a LevelDB super noob at the moment.