### PR TITLE
Write to stdout when the http server is listening

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,4 +21,7 @@ if (argv.help) {
   ].join('\n'))
 }
 
-require('./index.js')(argv).listen(argv.port || 4567)
+var port = argv.port || 4567
+require('./index.js')(argv).listen(port, function () {
+  console.log('Listening on port: %s', port)
+})


### PR DESCRIPTION
This makes it a easier to figure out when it's safe to start sending requests.  It also makes it a little less confusing when you start the server and it looks like nothing happened.