### PR TITLE
Fixes issue where SplitShard was causing hash key range to be represented in exponential notation

### DIFF
--- a/actions/splitShard.js
+++ b/actions/splitShard.js
@@ -97,7 +97,7 @@ module.exports = function splitShard(store, data, cb) {
                   ParentShardId: shardId,
                   HashKeyRange: {
                     StartingHashKey: shard.HashKeyRange.StartingHashKey,
-                    EndingHashKey: hashKey.minus(1).toString(),
+                    EndingHashKey: hashKey.minus(1).toFixed(),
                   },
                   SequenceNumberRange: {
                     StartingSequenceNumber: db.stringifySequence({
@@ -111,7 +111,7 @@ module.exports = function splitShard(store, data, cb) {
                 stream.Shards.push({
                   ParentShardId: shardId,
                   HashKeyRange: {
-                    StartingHashKey: hashKey.toString(),
+                    StartingHashKey: hashKey.toFixed(),
                     EndingHashKey: shard.HashKeyRange.EndingHashKey,
                   },
                   SequenceNumberRange: {


### PR DESCRIPTION
As per https://mikemcl.github.io/bignumber.js/, the default toString() implementation uses exponential notation beyond a certain value. Switching to toFixed() ensures the numeric representation is used. 

Repro steps - 
Start kinesalite, create a stream with 1 shard, issue a SplitShard against that stream. 
Something like 
aws kinesis split-shard --stream-name testStream --shard-to-split shardId-000000000000 --new-starting-hash-key 38056473384187692692674921486353642290 --endpoint-url http://127.0.0.1:4567
Now call DescribeStream, you'll notice output like 

"HashKeyRange": {
                    "EndingHashKey": "3.8056473384187692692674921486353642289e+37", 
                    "StartingHashKey": "0"
                }, 

With the fix, it becomes
"HashKeyRange": {
                    "EndingHashKey": "38056473384187692692674921486353642289", 
                    "StartingHashKey": "0"
                }, 

                