### PR TITLE
Fix NextShardIterator for compatibility with Kinesis Client Library (KCL)

### DIFF
--- a/actions/getRecords.js
+++ b/actions/getRecords.js
@@ -93,7 +93,15 @@ module.exports = function getRecords(store, data, cb) {
 
         if (!items.length && stream.Shards[shardIx].SequenceNumberRange.EndingSequenceNumber) {
           var endSeqObj = db.parseSequence(stream.Shards[shardIx].SequenceNumberRange.EndingSequenceNumber)
-          if (seqObj.seqTime >= endSeqObj.seqTime) {
+          /* To make kinesalite compatible with the Kinesis Client Library (KCL), we
+             always need to return an undefined nextShardIterator as soon as we arrive
+             at this point. Since `EndingSequenceNumber` is set, we can assume that
+             this shard has been closed as a result of a split or merge operation. Now,
+             if `items` is empty (because no new records get pushed to this closed shard),
+             then `lastItem` is always undefined, hence never allowing `nextSeq` to increase
+             in the assignment above, therefore resulting in an infinite polling loop
+             with always the exact same 'next' shard iterator returned to the KCL. */
+          if (true || seqObj.seqTime >= endSeqObj.seqTime) {
             nextShardIterator = undefined
             millisBehind = Math.max(0, Date.now() - endSeqObj.seqTime)
           }


### PR DESCRIPTION
First of all, thanks for publishing this project @mhart - kinesalite is really awesome! :)

This PR is about a minor compatibility issue with [Kinesis Client Library](https://github.com/awslabs/amazon-kinesis-client) (KCL) [1]. In general, the combination of kinesalite and dynalite works really well for local integration testing with KCL.

We have one test case, however, where KCL works properly with AWS Kinesis but fails to work with kinesalite. The test consists of 1 stream, 1 producer which constantly pushes records to the stream, and 1 consumer (KCL process) which continuously reads records. In parallel, we slowly increase the shard allocation by running a sequence of `SplitShard` API calls.

By constantly polling the stream description, the KCL figures out that new shards are added. The handover from the "old" shard (parent) to the "new" shards (children) happens as soon as the KCL determines that the end of the old shard has been reached. The responsible piece of code can be found [here](https://github.com/awslabs/amazon-kinesis-client/blob/c6e393c13ec348f77b8b08082ba56823776ee48a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java#L73) [2], essentially KCL checks whether `NextShardIterator` is `null`, then sets `isShardEndReached` to `true` and starts initializing the new child shards from that point onwards. The problem is that the condition `nextIterator == null` is never satisfied with kinesalite, at least not in our test setup (the issue is reproducible).

The change in this PR fixes this issue and allows KCL to reliably switch to the new shards after a split operation. See also the comment in the code which explains why the change is necessary.

It is hard to tell at this point which implications this change has for other bits of the framework, but our test results indicate that this actually best mimics the behavior of Kinesis. Judging from the unit test results of this project, this is a non-breaking change as all test cases are still succeeding.

Please consider accepting this change as it covers a crucial functionality for a majority of users (KCL is probably the most widely used tool to interact with Kinesis). If you figure out a better solution, I'll be happy to test it against our KCL testbed. Thanks

[1] https://github.com/awslabs/amazon-kinesis-client
[2] https://github.com/awslabs/amazon-kinesis-client/blob/c6e393c13ec348f77b8b08082ba56823776ee48a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisDataFetcher.java#L73