### PR TITLE
Fix duplicate records returned by GetRecords

### DIFF
--- a/actions/getRecords.js
+++ b/actions/getRecords.js
@@ -87,7 +87,11 @@ module.exports = function getRecords(store, data, cb) {
       })
       .filter(function(item) { return !item._tooOld })
       .join(function(items) {
-        var nextSeq = db.incrementSequence(lastItem ? lastItem._seqObj : seqObj, lastItem ? null : now),
+        var defaultTime = now
+        if (seqObj.seqTime > defaultTime) {
+          defaultTime = seqObj.seqTime
+        }
+        var nextSeq = db.incrementSequence(lastItem ? lastItem._seqObj : seqObj, lastItem ? null : defaultTime),
           nextShardIterator = db.createShardIterator(streamName, shardId, nextSeq),
           millisBehind = 0
 


### PR DESCRIPTION
Hi @mhart,

Thanks for a great library. It helps a lot in our testing :)
However, I noticed one of my tests started failing due to duplicated records being returned, and I think it's related to this recent change: 7384fccf
When calling GetRecords on a shard and getting no records less than a second after getting a record, incrementSequence can potentially move the seqTime of the next shard iterator backwards so that the next call gets the previous record again. This happens because when we get a record, it increments the seqTime to be a second after the record's time, but when we call GetRecords again in the same second and get no new records, it defaults to now, which gets truncated to be a second earlier than our current shard iterator.
This change makes sure that seqTime doesn't go backwards in this case. This change fixes my test, but I'm not sure it's the right fix or how it will interact with the expected behavior change in #34 
I created a [gist](https://gist.github.com/teamdoug/1a5403a337cb983faac3b716a678a67a) for a go binary that repros the behavior.
Please let me know if there's any more information I can provide.
