### PR TITLE
Handle properly SINGINT and SIGTERM signals

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,18 @@
 #!/usr/bin/env node
 
+// Handle signals properly
+// see: https://github.com/nodejs/node-v0.x-archive/issues/9131
+exitOnSignal('SIGINT');
+exitOnSignal('SIGTERM');
+
+function exitOnSignal(signal) {
+  process.on(signal, function() {
+    console.log('\ncaught ' + signal + ', exiting');
+    // perform all required cleanup
+    process.exit(0);
+  });
+}
+
 var argv = require('minimist')(process.argv.slice(2))
 
 if (argv.help) {


### PR DESCRIPTION
Hi @mhart,

This is a pull request to manage properly the `SINGINT` and `SIGTERM` signals when Kinesalite is bundle in a Docker container.

## Context 

The current behavior is due to a change introduced by [c61b0e9](https://github.com/nodejs/node-v0.x-archive/commit/c61b0e9cbc748c5e90fc5e25e4fb490b4104cae3) in Node. 

With this commit, when a user sends SIGINT by pressing CTRL-C in a terminal where node is the foreground process, the node process doesn't exit explicitly and instead forward the signal. 

Please read this issue for more information: https://github.com/nodejs/node-v0.x-archive/issues/9131

## Impact

When Kinesalite run in a Docker container (as `PID 1`) and we send a `SIGINT` or `SIGTERM` signal with `CTRL+C` the container does not exit properly:

```
CONTAINER ID        IMAGE                        STATUS               NAMES
51b1f016686b        saikocat/kinesalite:1.11.5   Exited (137)   kinesalite

```


