### PR TITLE
Added support for UpdateShardCound & DescribeLimits

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/actions/describeLimits.js
+++ b/actions/describeLimits.js
@@ -1,0 +1,10 @@
+var db = require('../db')
+
+module.exports = function describeLimits(store, data, cb) {
+
+  db.sumShards(store, function(err, shardSum) {
+    if (err) return cb(err)
+
+    cb(null, {OpenShardCount: shardSum, ShardLimit: store.shardLimit})
+  })
+}

--- a/actions/updateShardCount.js
+++ b/actions/updateShardCount.js
@@ -1,0 +1,96 @@
+var BigNumber = require('bignumber.js'),
+  db = require('../db'), createShards = require('./util.createShards')
+
+module.exports = function UpdateShardCount(store, data, cb) {
+
+  var metaDb = store.metaDb, key = data.StreamName, TargetShardCount = data.TargetShardCount
+
+  metaDb.lock(key, function(release) {
+    cb = release(cb)
+
+    store.getStream(key, function(err, stream) {
+      if (err) return cb(err)
+
+      if (stream.StreamStatus != 'ACTIVE') {
+        return cb(db.clientError('ResourceInUseException',
+          'Stream ' + data.StreamName + ' under account ' + metaDb.awsAccountId +
+          ' not ACTIVE, instead in state ' + stream.StreamStatus))
+      }
+
+      var openShards = stream.Shards.filter(function(shard) {
+        return shard.SequenceNumberRange.EndingSequenceNumber == null
+      }).length
+
+      if (TargetShardCount > store.shardLimit) {
+
+        return cb(db.clientError('LimitExceededException',
+          'Target shard count or number of open shards cannot be greater than ' + store.shardLimit + '. ' +
+          'Current open shard count: ' + openShards + ', Target shard count: ' + TargetShardCount))
+      }
+
+      if (TargetShardCount > openShards * 2) {
+
+        return cb(db.clientError('LimitExceededException',
+          'UpdateShardCount cannot scale up over double your current open shard count. ' +
+          'Current open shard count: ' + openShards + ', Target shard count: ' + TargetShardCount))
+      }
+
+      if (TargetShardCount < openShards / 2) {
+        return cb(db.clientError('LimitExceededException',
+          'UpdateShardCount cannot scale down below half your current open shard count. ' +
+          'Current open shard count: ' + openShards + ', Target shard count: ' + TargetShardCount))
+      }
+
+      if (stream.StreamStatus != 'ACTIVE') {
+        return cb(db.clientError('ResourceInUseException',
+          'Stream ' + key + ' under account ' + metaDb.awsAccountId +
+          ' not ACTIVE, instead in state ' + stream.StreamStatus))
+      }
+
+      stream.StreamStatus = 'UPDATING'
+
+      db.sumShards(store, function(err, shardSum) {
+        if (err) return cb(err)
+
+        metaDb.put(key, stream, function(err) {
+          if (err) return cb(err)
+
+          setTimeout(function() {
+
+            metaDb.lock(key, function(release) {
+              cb = release(function(err) {
+                if (err && !/Database is not open/.test(err)) console.error(err.stack || err)
+              })
+
+              store.getStream(key, function(err, stream) {
+                if (err && err.name == 'NotFoundError') return cb()
+                if (err) return cb(err)
+
+                stream.Shards.forEach(function(shard, index) {
+
+                  var now = Date.now()
+
+                  shard.SequenceNumberRange.EndingSequenceNumber = db.stringifySequence({
+                    shardCreateTime: db.parseSequence(shard.SequenceNumberRange.StartingSequenceNumber).shardCreateTime,
+                    shardIx: index,
+                    seqIx: new BigNumber('7fffffffffffffff', 16).toFixed(),
+                    seqTime: now,
+                  })
+
+                })
+
+                stream.Shards = stream.Shards.concat(createShards(TargetShardCount, shardSum))
+                stream.StreamStatus = 'ACTIVE'
+
+                metaDb.put(key, stream, cb)
+              })
+            })
+
+          }, store.updateStreamMs)
+
+          cb()
+        })
+      })
+    })
+  })
+}

--- a/actions/util.createShards.js
+++ b/actions/util.createShards.js
@@ -1,0 +1,27 @@
+var db = require('../db'),
+    BigNumber = require('bignumber.js'),
+    POW_128 = new BigNumber(2).pow(128),
+    SEQ_ADJUST_MS = 2000
+
+module.exports = function(shardCount, startIndex) {
+
+  startIndex = startIndex || 0
+
+  var i, shards = new Array(shardCount), shardHash = POW_128.div(shardCount).floor(),
+    createTime = Date.now() - SEQ_ADJUST_MS
+
+  for (i = 0; i < shardCount; i++) {
+    shards[i] = {
+      HashKeyRange: {
+        StartingHashKey: shardHash.times(i).toFixed(),
+        EndingHashKey: (i < shardCount - 1 ? shardHash.times(i + 1) : POW_128).minus(1).toFixed(),
+      },
+      SequenceNumberRange: {
+        StartingSequenceNumber: db.stringifySequence({shardCreateTime: createTime, shardIx: i}),
+      },
+      ShardId: db.shardIdName(startIndex + i),
+    }
+  }
+
+  return shards
+}

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ var MAX_REQUEST_BYTES = 7 * 1024 * 1024
 var validApis = ['Kinesis_20131202'],
     validOperations = ['AddTagsToStream', 'CreateStream', 'DeleteStream', 'DescribeStream', 'GetRecords',
       'GetShardIterator', 'ListStreams', 'ListTagsForStream', 'MergeShards', 'PutRecord', 'PutRecords',
-      'RemoveTagsFromStream', 'SplitShard', 'IncreaseStreamRetentionPeriod', 'DecreaseStreamRetentionPeriod'],
+      'RemoveTagsFromStream', 'SplitShard', 'IncreaseStreamRetentionPeriod', 'DecreaseStreamRetentionPeriod',
+      'UpdateShardCount', 'DescribeLimits'],
     actions = {},
     actionValidations = {}
 

--- a/test/describeLimits.js
+++ b/test/describeLimits.js
@@ -1,0 +1,24 @@
+var helpers = require('./helpers')
+
+var target = 'DescribeLimits',
+    request = helpers.request,
+    opts = helpers.opts.bind(null, target)
+
+describe('describeLimits', function() {
+
+  describe('functionality', function() {
+
+    // note there is already a stream due to helpers.before
+
+    it('should return current account limits', function(done) {
+      request(opts({}), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+        Object.keys(res.body).sort().should.eql(['OpenShardCount', 'ShardLimit'])
+        res.body.OpenShardCount.should.equal(3)
+        res.body.ShardLimit.should.equal(helpers.shardLimit)
+        done()
+      })
+    })
+  })
+})

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -31,6 +31,8 @@ exports.randomName = randomName
 exports.waitUntilActive = waitUntilActive
 exports.waitUntilDeleted = waitUntilDeleted
 exports.testStream = randomName()
+exports.createTestStreams = createTestStreams
+exports.deleteTestStreams = deleteTestStreams
 // For testing:
 // exports.testStream = '__kinesalite_test_1'
 
@@ -39,7 +41,7 @@ var port = 10000 + Math.round(Math.random() * 10000),
       {host: 'kinesis.' + exports.awsRegion + '.amazonaws.com', method: 'POST', ssl: true} :
       {host: '127.0.0.1', port: port, method: 'POST'}
 
-var kinesaliteServer = kinesalite({path: process.env.KINESALITE_PATH})
+var kinesaliteServer = kinesalite({path: process.env.KINESALITE_PATH, shardLimit: exports.shardLimit})
 
 before(function(done) {
   this.timeout(200000)

--- a/test/updateShardCount.js
+++ b/test/updateShardCount.js
@@ -1,0 +1,251 @@
+var BigNumber = require('bignumber.js'),
+    helpers = require('./helpers'),
+    db = require('../db')
+
+var target = 'UpdateShardCount',
+    request = helpers.request,
+    randomName = helpers.randomName,
+    opts = helpers.opts.bind(null, target),
+    assertType = helpers.assertType.bind(null, target),
+    assertValidation = helpers.assertValidation.bind(null, target),
+    assertNotFound = helpers.assertNotFound.bind(null, target),
+    assertInvalidArgument = helpers.assertInvalidArgument.bind(null, target),
+    assertInUse = helpers.assertInUse.bind(null, target),
+    assertLimitExceeded = helpers.assertLimitExceeded.bind(null, target)
+
+describe('updateShardCount', function() {
+
+  describe('serializations', function() {
+
+    it('should return SerializationException when StreamName is not a String', function(done) {
+      assertType('StreamName', 'String', done)
+    })
+
+    it('should return SerializationException when ScalingType is not a String', function(done) {
+      assertType('ScalingType', 'String', done)
+    })
+
+    it('should return SerializationException when TargetShardCount is not an Integer', function(done) {
+      assertType('TargetShardCount', 'Integer', done)
+    })
+
+  })
+
+  describe('validations', function() {
+
+    it('should return ValidationException for no StreamName', function(done) {
+      assertValidation({}, [
+        'Value null at \'scalingType\' failed to satisfy constraint: ' +
+        'Member must not be null',
+        'Value null at \'streamName\' failed to satisfy constraint: ' +
+        'Member must not be null',
+        'Value null at \'targetShardCount\' failed to satisfy constraint: ' +
+        'Member must not be null',
+      ], done)
+    })
+
+    it('should return ValidationException for empty StreamName', function(done) {
+      assertValidation({StreamName: '', ScalingType: '', TargetShardCount: 0}, [
+        'Value \'\' at \'scalingType\' failed to satisfy constraint: ' +
+        'Member must satisfy enum value set: [UNIFORM_SCALING]',
+        'Value \'\' at \'streamName\' failed to satisfy constraint: ' +
+        'Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+',
+        'Value \'\' at \'streamName\' failed to satisfy constraint: ' +
+        'Member must have length greater than or equal to 1',
+        'Value \'0\' at \'targetShardCount\' failed to satisfy constraint: ' +
+        'Member must have value greater than or equal to 1',
+      ], done)
+    })
+
+    it('should return ValidationException for long StreamName', function(done) {
+      var name = new Array(129 + 1).join('a')
+      assertValidation({StreamName: name, ScalingType: 'UNIFORM_SCALING', TargetShardCount: 1}, [
+        'Value \'' + name + '\' at \'streamName\' failed to satisfy constraint: ' +
+        'Member must have length less than or equal to 128',
+      ], done)
+    })
+
+    it('should return ValidationException for large TargetShardCount', function(done) {
+      assertValidation({StreamName: randomName(), ScalingType: 'UNIFORM_SCALING', TargetShardCount: 100001}, [
+        'Value \'100001\' at \'targetShardCount\' failed to satisfy constraint: ' +
+        'Member must have value less than or equal to 100000',
+      ], done)
+    })
+
+    it('should return ResourceNotFoundException if stream does not exist', function(done) {
+      var name = randomName()
+      assertNotFound({StreamName: name, ScalingType: 'UNIFORM_SCALING', TargetShardCount: 2},
+        'Stream ' + name + ' under account ' + helpers.awsAccountId + ' not found.', done)
+    })
+
+    it('should return LimitExceededException if increasing over shards limit', function(done) {
+      this.timeout(100000)
+      var stream = {StreamName: randomName(), ShardCount: helpers.shardLimit / 5}
+
+      request(helpers.opts('CreateStream', stream), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+
+        helpers.waitUntilActive(stream.StreamName, function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+
+          var targetShardCount = helpers.shardLimit + 2
+
+          assertLimitExceeded({StreamName: stream.StreamName, TargetShardCount: targetShardCount, ScalingType: "UNIFORM_SCALING"},
+            'Target shard count or number of open shards cannot be greater than ' + helpers.shardLimit + '. ' +
+            'Current open shard count: 10, Target shard count: ' + targetShardCount, function(err) {
+            if (err) return done(err)
+
+            request(helpers.opts('DeleteStream', {StreamName: stream.StreamName}), done)
+          })
+        })
+      })
+    })
+
+    it('should return LimitExceededException if scaling above double open shards', function(done) {
+      this.timeout(100000)
+      var stream = {StreamName: randomName(), ShardCount: 2}
+
+      request(helpers.opts('CreateStream', stream), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+
+        helpers.waitUntilActive(stream.StreamName, function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+
+          var targetShardCount = 6
+
+          assertLimitExceeded({StreamName: stream.StreamName, TargetShardCount: targetShardCount, ScalingType: "UNIFORM_SCALING"},
+            'UpdateShardCount cannot scale up over double your current open shard count. ' +
+            'Current open shard count: 2, Target shard count: ' + targetShardCount, function(err) {
+            if (err) return done(err)
+
+            request(helpers.opts('DeleteStream', {StreamName: stream.StreamName}), done)
+          })
+        })
+      })
+    })
+
+    it('should return LimitExceededException if scaling down below half open shards', function(done) {
+      this.timeout(100000)
+      var stream = {StreamName: randomName(), ShardCount: 6}
+
+      request(helpers.opts('CreateStream', stream), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+
+        helpers.waitUntilActive(stream.StreamName, function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+
+          var targetShardCount = 2
+
+          assertLimitExceeded({StreamName: stream.StreamName, TargetShardCount: targetShardCount, ScalingType: "UNIFORM_SCALING"},
+            'UpdateShardCount cannot scale down below half your current open shard count. ' +
+            'Current open shard count: 6, Target shard count: ' + targetShardCount, function(err) {
+            if (err) return done(err)
+
+            request(helpers.opts('DeleteStream', {StreamName: stream.StreamName}), done)
+          })
+        })
+      })
+    })
+  })
+
+  describe('functionality', function() {
+
+    it('should increase open stream shards to 4', function(done) {
+      this.timeout(100000)
+      var stream = {StreamName: randomName(), ShardCount: 2}
+
+      request(helpers.opts('CreateStream', stream), function(err, res) {
+        if (err) return done(err)
+
+        helpers.waitUntilActive(stream.StreamName, function(err, res) {
+
+          if (err) return done(err)
+
+          request(helpers.opts('UpdateShardCount', {
+            StreamName: stream.StreamName,
+            TargetShardCount: 4,
+            ScalingType: 'UNIFORM_SCALING',
+          }), function(err, res) {
+            if (err) return done(err)
+
+            res.statusCode.should.equal(200)
+            res.body.should.equal('')
+
+            request(helpers.opts('DescribeStream', stream), function(err, res) {
+
+              if (err) return done(err)
+              res.statusCode.should.equal(200)
+
+              res.body.StreamDescription.StreamStatus.should.eql('UPDATING');
+              res.body.StreamDescription.Shards.length.should.eql(2);
+
+              helpers.waitUntilActive(stream.StreamName, function(err, res) {
+
+                var shards = res.body.StreamDescription.Shards,
+                    closedShards = shards.filter(function(shard) {
+                      return shard.SequenceNumberRange.EndingSequenceNumber != null
+                    }).length
+
+                shards.length.should.eql(6)
+                closedShards.should.eql(2)
+                request(helpers.opts('DeleteStream', {StreamName: stream.StreamName}), done)
+              })
+            })
+          })
+        })
+      })
+    })
+
+    it('should decrease open stream shards to 2', function(done) {
+      this.timeout(100000)
+      var stream = {StreamName: randomName(), ShardCount: 4}
+
+      request(helpers.opts('CreateStream', stream), function(err, res) {
+        if (err) return done(err)
+
+        helpers.waitUntilActive(stream.StreamName, function(err, res) {
+
+          if (err) return done(err)
+
+          request(helpers.opts('UpdateShardCount', {
+            StreamName: stream.StreamName,
+            TargetShardCount: 2,
+            ScalingType: 'UNIFORM_SCALING',
+          }), function(err, res) {
+            if (err) return done(err)
+
+            res.statusCode.should.equal(200)
+            res.body.should.equal('')
+
+            request(helpers.opts('DescribeStream', stream), function(err, res) {
+
+              if (err) return done(err)
+              res.statusCode.should.equal(200)
+
+              res.body.StreamDescription.StreamStatus.should.eql('UPDATING');
+              res.body.StreamDescription.Shards.length.should.eql(4);
+
+              helpers.waitUntilActive(stream.StreamName, function(err, res) {
+
+                var shards = res.body.StreamDescription.Shards,
+                    closedShards = shards.filter(function(shard) {
+                      return shard.SequenceNumberRange.EndingSequenceNumber != null
+                    }).length
+
+                shards.length.should.eql(6)
+                closedShards.should.eql(4)
+                request(helpers.opts('DeleteStream', {StreamName: stream.StreamName}), done)
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/validations/describeLimits.js
+++ b/validations/describeLimits.js
@@ -1,0 +1,1 @@
+exports.types = {}

--- a/validations/updateShardCount.js
+++ b/validations/updateShardCount.js
@@ -1,0 +1,20 @@
+exports.types = {
+  ScalingType: {
+    type: 'String',
+    notNull: true,
+    enum: ['UNIFORM_SCALING'],
+  },
+  StreamName: {
+    type: 'String',
+    notNull: true,
+    regex: '[a-zA-Z0-9_.-]+',
+    lengthGreaterThanOrEqual: 1,
+    lengthLessThanOrEqual: 128,
+  },
+  TargetShardCount: {
+    type: 'Integer',
+    notNull: true,
+    greaterThanOrEqual: 1,
+    lessThanOrEqual: 100000,
+  },
+}


### PR DESCRIPTION
This change adds support for UpdateShardCount & DescribeLimits.

- [UpdateShardCound](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_UpdateShardCount.html)
- [DescribeLimits](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeLimits.html)

**Notable Additions**

*util.createShards*
The creation of shards is now a separate utility function as there was an overlap between creating a streams initial shards and adding further via UpdateShardCound.

*./test/helpers*
When creating an instance of kinesalite for testing, helpers.shardLimit was not passed as an option. This PR also address this.

*[.editorconfig](http://editorconfig.org/)* 
Added for future contributors convenience. 