### PR TITLE
Add support for AT_TIMESTAMP

### DIFF
--- a/test/getRecords.js
+++ b/test/getRecords.js
@@ -281,6 +281,93 @@ describe('getRecords', function() {
       })
     })
 
+    it('should return correct AT_TIMESTAMP records', function(done) {
+      var hashKey1 = new BigNumber(2).pow(128).minus(1).toFixed(),
+        hashKey2 = new BigNumber(2).pow(128).div(3).floor().times(2).minus(1).toFixed(),
+        hashKey3 = new BigNumber(2).pow(128).div(3).floor().times(2).toFixed(),
+        records1 = [
+          {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64')},
+          {PartitionKey: 'b', Data: crypto.randomBytes(10).toString('base64')},
+          {PartitionKey: 'e', Data: crypto.randomBytes(10).toString('base64')},
+          {PartitionKey: 'f', Data: crypto.randomBytes(10).toString('base64')},
+          {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64'), ExplicitHashKey: hashKey1},
+          {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64'), ExplicitHashKey: hashKey2},
+          {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64'), ExplicitHashKey: hashKey3},
+        ]
+      request(helpers.opts('PutRecords', {StreamName: helpers.testStream, Records: records1}), function(err, res) {
+        if (err) return done(err)
+        res.statusCode.should.equal(200)
+
+        var secondInsertSeconds = new Date().getTime() / 1000;
+
+        var hashKey1 = new BigNumber(2).pow(128).minus(1).toFixed(),
+          hashKey2 = new BigNumber(2).pow(128).div(3).floor().times(2).minus(1).toFixed(),
+          hashKey3 = new BigNumber(2).pow(128).div(3).floor().times(2).toFixed(),
+          records2 = [
+            {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64')},
+            {PartitionKey: 'b', Data: crypto.randomBytes(10).toString('base64')},
+            {PartitionKey: 'e', Data: crypto.randomBytes(10).toString('base64')},
+            {PartitionKey: 'f', Data: crypto.randomBytes(10).toString('base64')},
+            {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64'), ExplicitHashKey: hashKey1},
+            {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64'), ExplicitHashKey: hashKey2},
+            {PartitionKey: 'a', Data: crypto.randomBytes(10).toString('base64'), ExplicitHashKey: hashKey3},
+          ]
+
+        request(helpers.opts('PutRecords', {StreamName: helpers.testStream, Records: records2}), function(err, res) {
+          if (err) return done(err)
+          res.statusCode.should.equal(200)
+          var recordsPut2 = res.body.Records
+
+          request(helpers.opts('GetShardIterator', {
+            StreamName: helpers.testStream,
+            ShardId: 'shardId-1',
+            ShardIteratorType: 'AT_TIMESTAMP',
+            Timestamp: secondInsertSeconds
+          }), function(err, res) {
+            if (err) return done(err)
+            res.statusCode.should.equal(200)
+
+            var shardIterator = res.body.ShardIterator
+
+            request(opts({ShardIterator: shardIterator}), function(err, res) {
+              if (err) return done(err)
+              res.statusCode.should.equal(200)
+
+              delete res.body.MillisBehindLatest
+
+              helpers.assertShardIterator(res.body.NextShardIterator, helpers.testStream)
+              delete res.body.NextShardIterator
+
+              helpers.assertArrivalTimes(res.body.Records)
+              res.body.Records.forEach(function(record) { delete record.ApproximateArrivalTimestamp })
+
+              res.body.should.eql({
+                Records: [
+                  {
+                    PartitionKey: records2[1].PartitionKey,
+                    Data: records2[1].Data,
+                    SequenceNumber: recordsPut2[1].SequenceNumber,
+                  },
+                  {
+                    PartitionKey: records2[3].PartitionKey,
+                    Data: records2[3].Data,
+                    SequenceNumber: recordsPut2[3].SequenceNumber,
+                  },
+                  {
+                    PartitionKey: records2[5].PartitionKey,
+                    Data: records2[5].Data,
+                    SequenceNumber: recordsPut2[5].SequenceNumber,
+                  },
+                ],
+              })
+
+              done()
+            })
+          })
+        })
+      })
+    })
+
     it('should return LATEST records', function(done) {
       request(helpers.opts('GetShardIterator', {
         StreamName: helpers.testStream,

--- a/test/getShardIterator.js
+++ b/test/getShardIterator.js
@@ -30,7 +30,6 @@ describe('getShardIterator', function() {
     it('should return SerializationException when StreamName is not a String', function(done) {
       assertType('StreamName', 'String', done)
     })
-
   })
 
   describe('validations', function() {
@@ -224,6 +223,10 @@ describe('getShardIterator', function() {
         'while it was used in a call to a shard with shardId-000000000000', done)
     })
 
+    it('should return InvalidArgumentException if AT_TIMESTAMP and no Timestamp', function(done) {
+      assertInvalidArgument({StreamName: helpers.testStream, ShardId: 'shardId-0', ShardIteratorType: 'AT_TIMESTAMP'},
+        'Must specify timestampInMillis parameter for iterator of type AT_TIMESTAMP. Current request has no timestamp parameter.', done)
+    })
   })
 
   describe('functionality', function() {

--- a/validations/getShardIterator.js
+++ b/validations/getShardIterator.js
@@ -22,4 +22,7 @@ exports.types = {
     lengthGreaterThanOrEqual: 1,
     lengthLessThanOrEqual: 128,
   },
+  Timestamp: {
+    type: 'Double',
+  },
 }


### PR DESCRIPTION
This adds support for the AT_TIMESTAMP shard iterator type.

Note that only `Timestamp` number values are supported, not date
strings. The [AWS
documentation](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html)
is unclear as to whether date strings are officially supported— the
request syntax indicates only numbers are accepted, but some examples in
the docs and the behavior of the API suggest otherwise.