### PR TITLE
Added the ability to mock a ProvisionedThroughputExceededException on PutRecord

### DIFF
--- a/actions/putRecord.js
+++ b/actions/putRecord.js
@@ -3,11 +3,16 @@ var BigNumber = require('bignumber.js'),
 
 module.exports = function putRecord(store, data, cb) {
 
-  var key = data.StreamName, metaDb = store.metaDb, streamDb = store.getStreamDb(data.StreamName)
+  var key = data.StreamName, metaDb = store.metaDb, streamDb = store.getStreamDb(data.StreamName), throughputExceededPercent = store.throughputExceededPercent
 
   metaDb.lock(key, function(release) {
     cb = release(cb)
 
+    if (throughputExceededPercent > 0) {
+      if(Math.floor(Math.random()*100) < throughputExceededPercent) {
+        return cb(db.clientError('ProvisionedThroughputExceededException', 'Rate exceeded for shard shardId-000000000000 in stream ' + data.StreamName + ' under account ' + metaDb.awsAccountId + ' .'))
+      }
+    }
     store.getStream(data.StreamName, function(err, stream) {
       if (err) return cb(err)
 

--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ if (argv.help) {
     '--deleteStreamMs <ms>  Amount of time streams stay in DELETING state (default: 500)',
     '--updateStreamMs <ms>  Amount of time streams stay in UPDATING state (default: 500)',
     '--shardLimit <limit>   Shard limit for error reporting (default: 10)',
+    '--throughputExceededPercent <percent>   Percent Chance to return a ProvisionedThroughputExceededException on PutRecord (default 0)',
     '',
     'Report bugs at github.com/mhart/kinesalite/issues',
   ].join('\n'))

--- a/db/index.js
+++ b/db/index.js
@@ -27,6 +27,7 @@ function create(options) {
   if (options.deleteStreamMs == null) options.deleteStreamMs = 500
   if (options.updateStreamMs == null) options.updateStreamMs = 500
   if (options.shardLimit == null) options.shardLimit = 10
+  if (options.throughputExceededPercent == null) options.throughputExceededPercent = 0
 
   var db = levelup(options.path || '/does/not/matter', options.path ? {} : {db: memdown}),
       sublevelDb = sublevel(db),
@@ -90,6 +91,7 @@ function create(options) {
     deleteStreamDb: deleteStreamDb,
     getStream: getStream,
     recreate: recreate,
+    throughputExceededPercent: options.throughputExceededPercent
   }
 }
 


### PR DESCRIPTION
I needed to test some client changes to handle a ProvisionedThroughputExceededException and I found your library that pretended to be Kinesis.  It was close enough to the real thing, and I was able to add a command line parameter to simulate a X percent chance to have a ProvisionedThrougputExceededException.  I've submitted a pull request just in case you think anyone else would find this useful. 