### PR TITLE
Allow up to 50 tags per stream

### DIFF
--- a/actions/addTagsToStream.js
+++ b/actions/addTagsToStream.js
@@ -29,7 +29,7 @@ module.exports = function addTagsToStream(store, data, cb) {
         return obj
       }, {})
 
-      if (Object.keys(newKeys).length > 10)
+      if (Object.keys(newKeys).length > 50)
         return cb(db.clientError('InvalidArgumentException',
           'Failed to add tags to stream ' + data.StreamName + ' under account ' + metaDb.awsAccountId +
           ' because a given stream cannot have more than 10 tags associated with it.'))


### PR DESCRIPTION
A kinesis stream supports up to 50 tags per stream (although the error message reported by AWS indicates that only a total of 10 tags can be added)

http://docs.aws.amazon.com/kinesis/latest/APIReference/API_AddTagsToStream.html