### PR TITLE
ability to disable shard limits

### DIFF
--- a/actions/createStream.js
+++ b/actions/createStream.js
@@ -20,7 +20,7 @@ module.exports = function createStream(store, data, cb) {
       db.sumShards(store, function(err, shardSum) {
         if (err) return cb(err)
 
-        if (shardSum + data.ShardCount > store.shardLimit) {
+        if (store.shardLimit > 0 && shardSum + data.ShardCount > store.shardLimit) {
           return cb(db.clientError('LimitExceededException',
               'This request would exceed the shard limit for the account ' + metaDb.awsAccountId + ' in ' +
               metaDb.awsRegion + '. Current shard count for the account: ' + shardSum +

--- a/actions/splitShard.js
+++ b/actions/splitShard.js
@@ -36,7 +36,7 @@ module.exports = function splitShard(store, data, cb) {
       db.sumShards(store, function(err, shardSum) {
         if (err) return cb(err)
 
-        if (shardSum + 1 > store.shardLimit) {
+        if (store.shardLimit > 0 && shardSum + 1 > store.shardLimit) {
           return cb(db.clientError('LimitExceededException',
               'This request would exceed the shard limit for the account ' + metaDb.awsAccountId + ' in ' +
               metaDb.awsRegion + '. Current shard count for the account: ' + shardSum +

--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,7 @@ if (argv.help) {
     '--createStreamMs <ms>  Amount of time streams stay in CREATING state (default: 500)',
     '--deleteStreamMs <ms>  Amount of time streams stay in DELETING state (default: 500)',
     '--updateStreamMs <ms>  Amount of time streams stay in UPDATING state (default: 500)',
-    '--shardLimit <limit>   Shard limit for error reporting (default: 10)',
+    '--shardLimit <limit>   Shard limit for error reporting (default: 10), 0 to disable.',
     '',
     'Report bugs at github.com/mhart/kinesalite/issues',
   ].join('\n'))


### PR DESCRIPTION
When keeping a local server running over an extended period of time, and generating a lot of single-use streams (for test isolation), enforcing a limit becomes problematic. Allow the user to set shardLimit = 0 (to disable).