### PR TITLE
Permit colon character in Kinesis tag keys and values

### DIFF
--- a/actions/addTagsToStream.js
+++ b/actions/addTagsToStream.js
@@ -13,16 +13,16 @@ module.exports = function addTagsToStream(store, data, cb) {
       var keys = Object.keys(data.Tags), values = keys.map(function(key) { return data.Tags[key] }),
         all = keys.concat(values)
 
-      if (all.some(function(key) { return /[^\u00C0-\u1FFF\u2C00-\uD7FF\w\.\/\-=+_ @%]/.test(key) }))
+      if (all.some(function(key) { return /[^\u00C0-\u1FFF\u2C00-\uD7FF\w\.\/\-=+_ @%:]/.test(key) }))
         return cb(db.clientError('InvalidArgumentException',
           'Some tags contain invalid characters. Valid characters: ' +
-          'Unicode letters, digits, white space, _ . / = + - % @.'))
+          'Unicode letters, digits, white space, _ . / = + - % @ :.'))
 
       if (all.some(function(key) { return ~key.indexOf('%') }))
         return cb(db.clientError('InvalidArgumentException',
           'Failed to add tags to stream ' + data.StreamName + ' under account ' + metaDb.awsAccountId +
           ' because some tags contained illegal characters. The allowed characters are ' +
-          'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\'.'))
+          'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\',\':\'.'))
 
       var newKeys = keys.concat(Object.keys(stream._tags)).reduce(function(obj, key) {
         obj[key] = true

--- a/actions/removeTagsFromStream.js
+++ b/actions/removeTagsFromStream.js
@@ -10,16 +10,16 @@ module.exports = function removeTagsFromStream(store, data, cb) {
     store.getStream(data.StreamName, function(err, stream) {
       if (err) return cb(err)
 
-      if (data.TagKeys.some(function(key) { return /[^\u00C0-\u1FFF\u2C00-\uD7FF\w\.\/\-=+_ @%]/.test(key) }))
+      if (data.TagKeys.some(function(key) { return /[^\u00C0-\u1FFF\u2C00-\uD7FF\w\.\/\-=+_ @%:]/.test(key) }))
         return cb(db.clientError('InvalidArgumentException',
           'Some tags contain invalid characters. Valid characters: ' +
-          'Unicode letters, digits, white space, _ . / = + - % @.'))
+          'Unicode letters, digits, white space, _ . / = + - % @ :.'))
 
       if (data.TagKeys.some(function(key) { return ~key.indexOf('%') }))
         return cb(db.clientError('InvalidArgumentException',
           'Failed to remove tags from stream ' + data.StreamName + ' under account ' + metaDb.awsAccountId +
           ' because some tags contained illegal characters. The allowed characters are ' +
-          'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\'.'))
+          'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\',\':\'.'))
 
       data.TagKeys.forEach(function(key) {
         delete stream._tags[key]

--- a/test/addTagsToStream.js
+++ b/test/addTagsToStream.js
@@ -93,63 +93,63 @@ describe('addTagsToStream', function() {
     it('should return InvalidArgumentException if ; in tag key', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {'abc;def': '1'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if tab in tag key', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {'abc\tdef': '1'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if newline in tag key', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {'abc\ndef': '1'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if comma in tag key', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {'abc,def': '1'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if % in tag key', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {'abc%def': '1'}},
         'Failed to add tags to stream ' + helpers.testStream + ' under account ' + helpers.awsAccountId +
         ' because some tags contained illegal characters. The allowed characters are ' +
-        'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\'.', done)
+        'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\',\':\'.', done)
     })
 
     it('should return InvalidArgumentException if ; in tag value', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {a: 'abc;def'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if tab in tag value', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {a: 'abc\tdef'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if newline in tag value', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {a: 'abc\ndef'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if comma in tag value', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {a: 'abc,def'}},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if % in tag value', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, Tags: {a: 'abc%def'}},
         'Failed to add tags to stream ' + helpers.testStream + ' under account ' + helpers.awsAccountId +
         ' because some tags contained illegal characters. The allowed characters are ' +
-        'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\'.', done)
+        'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\',\':\'.', done)
     })
 
   })
@@ -159,7 +159,7 @@ describe('addTagsToStream', function() {
     it('should add and remove tags keys', function(done) {
       request(opts({
         StreamName: helpers.testStream,
-        Tags: {a: 'a', 'ü0 _.': 'a', '/=+-@': 'a', b: 'ü0 _./=+-@', c: ''},
+        Tags: {a: 'a', 'ü0 _.': 'a', '/=+-@:': 'a', b: 'ü0 _./=+-@', c: ''},
       }), function(err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
@@ -191,7 +191,7 @@ describe('addTagsToStream', function() {
             res.statusCode.should.equal(200)
             res.body.Tags.should.containEql({Key: 'a', Value: 'a'})
             res.body.Tags.should.containEql({Key: 'ü0 _.', Value: 'a'})
-            res.body.Tags.should.containEql({Key: '/=+-@', Value: 'a'})
+            res.body.Tags.should.containEql({Key: '/=+-@:', Value: 'a'})
             res.body.Tags.should.containEql({Key: 'b', Value: 'ü0 _./=+-@'})
             res.body.Tags.should.containEql({Key: 'c', Value: ''})
 
@@ -204,7 +204,7 @@ describe('addTagsToStream', function() {
                 res.statusCode.should.equal(200)
                 res.body.Tags.should.containEql({Key: 'a', Value: 'b'})
                 res.body.Tags.should.containEql({Key: 'ü0 _.', Value: 'a'})
-                res.body.Tags.should.containEql({Key: '/=+-@', Value: 'a'})
+                res.body.Tags.should.containEql({Key: '/=+-@:', Value: 'a'})
                 res.body.Tags.should.containEql({Key: 'b', Value: 'ü0 _./=+-@'})
                 res.body.Tags.should.containEql({Key: 'c', Value: ''})
 

--- a/test/removeTagsFromStream.js
+++ b/test/removeTagsFromStream.js
@@ -82,32 +82,32 @@ describe('removeTagsFromStream', function() {
     it('should return InvalidArgumentException if ; in TagKeys', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, TagKeys: ['abc;def']},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if tab in TagKeys', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, TagKeys: ['abc\tdef']},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if newline in TagKeys', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, TagKeys: ['abc\ndef']},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if comma in TagKeys', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, TagKeys: ['abc,def']},
         'Some tags contain invalid characters. Valid characters: ' +
-        'Unicode letters, digits, white space, _ . / = + - % @.', done)
+        'Unicode letters, digits, white space, _ . / = + - % @ :.', done)
     })
 
     it('should return InvalidArgumentException if % in TagKeys', function(done) {
       assertInvalidArgument({StreamName: helpers.testStream, TagKeys: ['abc%def']},
         'Failed to remove tags from stream ' + helpers.testStream + ' under account ' + helpers.awsAccountId +
         ' because some tags contained illegal characters. The allowed characters are ' +
-        'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\'.', done)
+        'Unicode letters, white-spaces, \'_\',\',\',\'/\',\'=\',\'+\',\'-\',\'@\',\':\'.', done)
     })
 
   })
@@ -115,7 +115,7 @@ describe('removeTagsFromStream', function() {
   describe('functionality', function() {
 
     it('should succeed if valid characters in tag keys', function(done) {
-      request(opts({StreamName: helpers.testStream, TagKeys: ['ü0 _.', '/=+-@']}), function(err, res) {
+      request(opts({StreamName: helpers.testStream, TagKeys: ['ü0 _.', '/=+-@:']}), function(err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
         res.body.should.equal('')
@@ -126,7 +126,7 @@ describe('removeTagsFromStream', function() {
     it('should add and remove tags keys', function(done) {
       request(helpers.opts('AddTagsToStream', {
         StreamName: helpers.testStream,
-        Tags: {a: 'a', 'ü0 _.': 'a', '/=+-@': 'a'},
+        Tags: {a: 'a', 'ü0 _.': 'a', '/=+-@:': 'a'},
       }), function(err, res) {
         if (err) return done(err)
         res.statusCode.should.equal(200)
@@ -136,9 +136,9 @@ describe('removeTagsFromStream', function() {
           res.statusCode.should.equal(200)
           res.body.Tags.should.containEql({Key: 'a', Value: 'a'})
           res.body.Tags.should.containEql({Key: 'ü0 _.', Value: 'a'})
-          res.body.Tags.should.containEql({Key: '/=+-@', Value: 'a'})
+          res.body.Tags.should.containEql({Key: '/=+-@:', Value: 'a'})
 
-          request(opts({StreamName: helpers.testStream, TagKeys: ['ü0 _.', '/=+-@', 'b', 'c']}), function(err, res) {
+          request(opts({StreamName: helpers.testStream, TagKeys: ['ü0 _.', '/=+-@:', 'b', 'c']}), function(err, res) {
             if (err) return done(err)
             res.statusCode.should.equal(200)
             res.body.should.equal('')
@@ -148,7 +148,7 @@ describe('removeTagsFromStream', function() {
               res.statusCode.should.equal(200)
               res.body.Tags.should.containEql({Key: 'a', Value: 'a'})
               res.body.Tags.should.not.containEql({Key: 'ü0 _.', Value: 'a'})
-              res.body.Tags.should.not.containEql({Key: '/=+-@', Value: 'a'})
+              res.body.Tags.should.not.containEql({Key: '/=+-@:', Value: 'a'})
 
               request(opts({StreamName: helpers.testStream, TagKeys: ['a']}), done)
             })


### PR DESCRIPTION
In spite of the AWS Kinesis documentation stating the contrary (https://docs.aws.amazon.com/streams/latest/dev/tagging.html#tagging-restrictions), AWS permits tags with colon in either key or value. This is a proposal to add support for colons.

Addresses https://github.com/mhart/kinesalite/issues/107