### PR TITLE
Fix invalid record data returned after CBOR-encoded put request

### DIFF
--- a/validations/index.js
+++ b/validations/index.js
@@ -82,7 +82,9 @@ function checkTypes(data, types) {
           case 'number':
             throw typeError('class com.amazon.coral.value.json.numbers.TruncatingBigNumber can not be converted to a Blob')
           case 'object':
-            if (Buffer.isBuffer(val)) return val
+            // Blob could be a Buffer object when coming from CBOR request.
+            // Return base64-encoded string to match with the behavior of JSON requests.
+            if (Buffer.isBuffer(val)) return val.toString('base64')
             if (Array.isArray(val)) throw typeError('Start of list found where not expected')
             throw typeError('Start of structure or map found where not expected.')
         }


### PR DESCRIPTION
# Problem

1. Put record with CBOR-encoded request (e.g. using AWS Java SDK)
2. Get records -> malformed JSON response

```
{
    "Records": [
        ...
        {
            "SequenceNumber": "49616645143474350269062001186086684333515393213082370050",
            "ApproximateArrivalTimestamp": 1616506576.795,
            "Data": {
                "type": "Buffer",
                "data": [
                    104,
                    101,
                    108,
                    108,
                    111
                ]
            },
            "PartitionKey": "hello"
        },
        ...
    ],
    ...
}
```

`Data` should be base64-encoded string but Buffer object is stringified as-is.

# Proposed fix

If `Buffer` is given as `Blob` typed parameter, convert it into base64-encoded string.

An alternative approach could be: encode `Buffer`s when writing responses.

Related: #108 
